### PR TITLE
hide backface visibility for macos chrome

### DIFF
--- a/src/styles/mystyles.scss
+++ b/src/styles/mystyles.scss
@@ -54,6 +54,7 @@ nav {
 
 main {
   font-family: $family-serif;
+  backface-visibility: hidden;
   color: $white;
   font-size: $font-large;
   position: absolute;


### PR DESCRIPTION
This fixes the flickering issue on the left column when  you scroll on Chrome for MacOS.

Firefox for MacOS and Chrome/Firefox for Windows look good. So it must be some weird specific rendering issue.

We set `backface-visibility: hidden` for `main` (right column) so we don't see it pop up when the left hand column is being re-rendered on scroll. 
https://developer.mozilla.org/en-US/docs/Web/CSS/backface-visibility